### PR TITLE
Fix Bug with Creating Links When Vanity String has already been used

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -3,6 +3,8 @@ class LinksController < ApplicationController
   include ConstantsHelper
 
   def create
+    return unless short_url_unique?
+
     @link = Link.new(link_params)
 
     if @link.save
@@ -13,6 +15,28 @@ class LinksController < ApplicationController
   end
 
   private
+
+    def short_url_unique?
+      return if short_link_taken?
+      return if anon_passing_short_link?
+      true
+    end
+
+    def short_link_taken?
+      if current_user && Link.find_by(short_url: params[:link][:short_url])
+        flash[:error] = URL_TAKEN
+        redirect_back_or_to root_path
+        true
+      end
+    end
+
+    def anon_passing_short_link?
+      if !current_user && params[:link][:short_url]
+        flash[:error] = NO_PERMISSION
+        redirect_back_or_to root_path
+        true
+      end
+    end
 
     def url_save_success
       flash[:url] = link_url(@link)

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe LinksController, type: :request do
+  include_context "shared stuff"
+
+  it "raises an error when anonymous user passes in short link" do
+    post links_path, link: {
+      full_url: urls[1], short_url: vanity
+    }
+    expect(flash[:error]).to eql(
+      "Permission not granted."
+    )
+  end
+end

--- a/spec/features/user_create_spec.rb
+++ b/spec/features/user_create_spec.rb
@@ -31,5 +31,18 @@ describe "Link-Creation for Logged-In Users" do
         text: "/#{vanity}"
       )
     end
+
+    it "raises error when url has been chosen", js: true do
+      visit login_path
+      login_helper
+      fill_in "Full URL", with: urls[1]
+      fill_in "Custom URL", with: vanity
+      click_button "Gobble"
+
+      expect(page).to have_css(
+        "#toast-container",
+        text: "URL already taken"
+      )
+    end
   end
 end


### PR DESCRIPTION
Why?
Users should be notified when the vanity string they're passing in has already been used by someone else.

How?
Correct Link controller to first check if vanity string is unique before using to shorten.
If vanity string is not unique, an error message is displayed.
