### PR TITLE
Fix Bug with Creating Links When Vanity String conflicts with an inte…

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -4,6 +4,7 @@ class LinksController < ApplicationController
 
   def create
     return unless short_url_unique?
+    return if reserved_word?
 
     @link = Link.new(link_params)
 
@@ -36,6 +37,19 @@ class LinksController < ApplicationController
         redirect_back_or_to root_path
         true
       end
+    end
+
+    def reserved_word?
+      reserved_words = %w(
+        login logout home signup
+        api edit links users
+      )
+      value_present = reserved_words.include?(params[:link][:short_url])
+      return unless value_present
+
+      flash[:error] = PATH_RESERVED
+      redirect_back_or_to root_path
+      true
     end
 
     def url_save_success

--- a/spec/features/user_create_spec.rb
+++ b/spec/features/user_create_spec.rb
@@ -44,5 +44,18 @@ describe "Link-Creation for Logged-In Users" do
         text: "URL already taken"
       )
     end
+
+    it "raises error when url is an internal path", js: true do
+      visit login_path
+      login_helper
+      fill_in "Full URL", with: urls[1]
+      fill_in "Custom URL", with: reserved_word
+      click_button "Gobble"
+
+      expect(page).to have_css(
+        "#toast-container",
+        text: "Path reserved."
+      )
+    end
   end
 end


### PR DESCRIPTION
…rnal path

Why?
Users should be notified when the vanity string they're passing in is a reserved path

How?
Correct Link controller to first check if vanity string is a reserved path before using to shorten.
If vanity string is a reserved path, an error message is displayed.
