### PR TITLE
Redirection for Shortened Links

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -15,6 +15,12 @@ class LinksController < ApplicationController
     end
   end
 
+  def process_url
+    @link = Link.find_by(short_url: params[:short_url])
+    return if no_link_yet?
+    action_for_link_url
+  end
+
   private
 
     def short_url_unique?
@@ -72,5 +78,38 @@ class LinksController < ApplicationController
     def url_save_failure
       flash[:error] = ENTRY_INVALID
       redirect_back_or_to root_path
+    end
+
+    def no_link_yet?
+      unless @link
+        flash[:error] = LINK_NOT_CREATED
+        redirect_to root_path
+        true
+      end
+    end
+
+    def action_for_link_url
+      return if link_deleted?
+      return if link_not_active?
+  
+      @link.count += 1
+      @link.save
+      redirect_to @link.full_url
+    end
+
+    def link_deleted?
+      if @link.deleted
+        flash[:error] = LINK_DELETED
+        redirect_to root_path
+        true
+      end
+    end
+
+    def link_not_active?
+      unless @link.active
+        flash[:error] = LINK_DISABLED
+        redirect_to root_path
+        true
+      end
     end
 end

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -91,7 +91,7 @@ class LinksController < ApplicationController
     def action_for_link_url
       return if link_deleted?
       return if link_not_active?
-  
+
       @link.count += 1
       @link.save
       redirect_to @link.full_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
   get "/login", to: "sessions#new", as: :login
   delete "/logout", to: "sessions#destroy", as: :logout
   resources :links
+  get '/:short_url' => 'links#process_url'
+  get '*path' => redirect('/')
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   get "/login", to: "sessions#new", as: :login
   delete "/logout", to: "sessions#destroy", as: :logout
   resources :links
-  get '/:short_url' => 'links#process_url'
-  get '*path' => redirect('/')
+  get "/:short_url" => "links#process_url"
+  get "*path" => redirect("/")
 end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -11,4 +11,24 @@ describe LinksController, type: :request do
       "Permission not granted."
     )
   end
+  
+  it "raises an error when an inactive link is visited" do
+    test_link = Link.new(full_url: urls[1], short_url: vanity, active: false)
+    test_link.save
+    get "/#{vanity}"
+    expect(flash[:error]).to eql(
+      "Link disabled by Creator"
+    )
+    test_link.destroy
+  end
+  
+  it "raises an error when a deleted link is visited" do
+    test_link = Link.new(full_url: urls[1], short_url: vanity, deleted: true)
+    test_link.save
+    get "/#{vanity}"
+    expect(flash[:error]).to eql(
+      "Link deleted by Creator"
+    )
+    test_link.destroy
+  end
 end

--- a/spec/controllers/links_controller_spec.rb
+++ b/spec/controllers/links_controller_spec.rb
@@ -11,7 +11,7 @@ describe LinksController, type: :request do
       "Permission not granted."
     )
   end
-  
+
   it "raises an error when an inactive link is visited" do
     test_link = Link.new(full_url: urls[1], short_url: vanity, active: false)
     test_link.save
@@ -21,7 +21,7 @@ describe LinksController, type: :request do
     )
     test_link.destroy
   end
-  
+
   it "raises an error when a deleted link is visited" do
     test_link = Link.new(full_url: urls[1], short_url: vanity, deleted: true)
     test_link.save

--- a/spec/features/user_create_spec.rb
+++ b/spec/features/user_create_spec.rb
@@ -18,7 +18,7 @@ describe "Link-Creation for Logged-In Users" do
     it "shortens urls by logged-in users", js: true do
       visit login_path
       login_helper
-      fill_in "Full URL", with: urls[0]
+      fill_in "Full URL", with: urls[1]
       fill_in "Custom URL", with: vanity
       click_button "Gobble"
 
@@ -32,10 +32,23 @@ describe "Link-Creation for Logged-In Users" do
       )
     end
 
+    it "redirects properly", js: true do
+      visit "/#{vanity}"
+      expect(page).to have_content('Sample "Hello, World" Application')
+    end
+    
+    it "raises error when an uncreated path is visited", js: true do
+      visit "/#{vanity}ad"
+      expect(page).to have_css(
+        "#toast-container",
+        text: "Link not created yet"
+      )
+    end
+
     it "raises error when url has been chosen", js: true do
       visit login_path
       login_helper
-      fill_in "Full URL", with: urls[1]
+      fill_in "Full URL", with: urls[0]
       fill_in "Custom URL", with: vanity
       click_button "Gobble"
 

--- a/spec/features/user_create_spec.rb
+++ b/spec/features/user_create_spec.rb
@@ -36,7 +36,7 @@ describe "Link-Creation for Logged-In Users" do
       visit "/#{vanity}"
       expect(page).to have_content('Sample "Hello, World" Application')
     end
-    
+
     it "raises error when an uncreated path is visited", js: true do
       visit "/#{vanity}ad"
       expect(page).to have_css(


### PR DESCRIPTION
Why?
When shortened URLs are visited, users should be redirected to the Full URL used to create them.

How?
Add a method in the links controller for handling redirection. If link is inactive or deleted, a message is shown to users.
