### PR TITLE
Disable Indentation Check by Rubocop On CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,27 @@
+---
+engines:
+  bundler-audit:
+    enabled: true
+  coffeelint:
+    enabled: true
+  eslint:
+    enabled: true
+  fixme:
+    enabled: true
+  rubocop:
+    enabled: true
+    checks:
+      Rubocop/Style/IndentationConsistency:
+        enabled: false
+ratings:
+  paths:
+  - Gemfile.lock
+  - "**.coffee"
+  - "**.js"
+  - "**.jsx"
+  - "**.rb"
+exclude_paths:
+- config/**/*
+- db/**/*
+- spec/**/*
+- vendor/**/*


### PR DESCRIPTION
Why?
To fix drop in code quality after indenting private methods under private
