### PR TITLE
Clipboard Copy For Shortened Links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "sorcery"
 gem "validates_email_format_of"
 gem "valid_url"
 gem "materialize-sass"
+gem 'zeroclipboard-rails'
 gem "sdoc", "~> 0.4.0", group: :doc
 gem "coveralls", require: false
 gem "draper"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,8 @@ GEM
     websocket (1.2.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zeroclipboard-rails (0.1.1)
+      railties (>= 3.1)
 
 PLATFORMS
   ruby
@@ -269,6 +271,7 @@ DEPENDENCIES
   valid_url
   validates_email_format_of
   web-console (~> 2.0)
+  zeroclipboard-rails
 
 BUNDLED WITH
    1.10.6

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,4 +15,5 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require materialize
+//= require zeroclipboard
 //= require_tree .

--- a/app/assets/javascripts/clipboard.js
+++ b/app/assets/javascripts/clipboard.js
@@ -1,0 +1,9 @@
+$(document).ready(function(){
+	new ZeroClipboard($("#clip_button"));
+	$("#clip_button").click(function() {
+    	Materialize.toast(
+			"Link copied to Clipboard",
+    		5000, "white black-text rounded"
+		);
+  	});
+});

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,11 +19,6 @@ module ApplicationHelper
     render partial: "custom_url", object: form_obj, as: "f"
   end
 
-  def show_link_box
-    return unless flash[:url]
-    render partial: "link_box"
-  end
-
   def show_toast_message
     if flash[:success] && !flash[:url]
       render partial: "toast_message", object: flash[:success], as: "message"

--- a/app/views/application/_link_box.html.erb
+++ b/app/views/application/_link_box.html.erb
@@ -4,3 +4,6 @@
 		<span class="white-text center"><%= link_to flash[:success], flash[:url], class: 'white-text url-link' %></span><br />
 	</div>
 </div>
+<button class='btn waves-effect waves-light btn-medium brand-bg white-text regular-text' data-clipboard-text= <%= flash[:url] %> id='clip_button'>
+Copy Link to Clipboard
+</button>

--- a/app/views/application/_shorten.html.erb
+++ b/app/views/application/_shorten.html.erb
@@ -1,5 +1,5 @@
 <div class="shorten-body z-depth-1 valign-wrapper">
-	<%= render 'url_form' %>
-	<%= show_link_box %>
+	<%= render "url_form" %>
+	<%= render "link_box" if flash[:url] %>
 	</div>
 </div>


### PR DESCRIPTION
Why?
To enhance user experience by allowing users easily copy shortened links.

How?
Using the zeroclipboard-rails gem.
